### PR TITLE
fix: resolve failing tests, lint, and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,25 +24,24 @@ jobs:
           find . -name "*.sh" -not -path "./.git/*" -not -path "./node_modules/*" | \
             xargs shellcheck --severity=warning 2>&1 | head -50 || echo "⚠️ shellcheck warnings above"
         continue-on-error: true
-      - name: ✅ ShellCheck complete
-        run: echo "ShellCheck finished"
 
   test:
-    name: CLI Tests
+    name: Tests
     runs-on: [self-hosted, linux, arm64, blackroad]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-      - name: Install deps
-        run: npm install --if-present --quiet 2>/dev/null || true
-      - name: Run tests
-        run: npm test --if-present 2>/dev/null || echo "✓ no tests yet"
-        continue-on-error: true
-      - name: Check br script
-        run: |
-          [ -f br ] && bash -n br && echo "✓ br script syntax OK" || echo "⚠️ br not found"
-        continue-on-error: true
-      - name: ✅ CLI Tests complete
-        run: echo "CLI tests finished"
+          node-version: '22'
+      - name: Install dependencies
+        run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit
+      - name: Lint
+        run: npx prettier --check .
+      - name: Unit tests
+        run: npm test
+      - name: Gateway tests
+        run: node --test blackroad-core/tests/gateway.test.js
+      - name: Check br script syntax
+        run: bash -n br

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,60 @@
+# Build output
+dist/
+node_modules/
+
+# Non-TS project directories (checked separately)
+blackroad-core/
+blackroad-os/
+blackroad-sf/
+blackroad-web/
+blackroad-math/
+blackroad-hardware/
+orgs/
+repos/
+agents/
+carpool/
+cli-scripts/
+control-map/
+coordination/
+dashboard/
+dashboards/
+deployments/
+devices/
+extensions/
+features/
+lib/
+mcp-bridge/
+migration/
+myscripts/
+ollama-wrapper/
+prompts/
+scripts/
+shared/
+state/
+templates/
+tools/
+visual/
+wavecube/
+websites/
+workers/
+
+# Markdown docs
+*.md
+
+# Shell scripts
+*.sh
+
+# Python
+*.py
+
+# Config, CI, and data files
+.blackroad/
+.codex/
+.github/
+*.golden
+*.json
+!package.json
+!tsconfig.json
+!vitest.config.ts
+*.html
+package-lock.json

--- a/blackroad-core/package.json
+++ b/blackroad-core/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "commonjs"
+}

--- a/src/bootstrap/templates.ts
+++ b/src/bootstrap/templates.ts
@@ -11,16 +11,20 @@ export const templates: ProjectTemplate[] = [
     name: 'worker',
     description: 'Cloudflare Worker project',
     files: {
-      'src/index.ts': '// Copyright (c) 2025-2026 BlackRoad OS, Inc.\nexport default { fetch: () => new Response("Hello") }',
-      'wrangler.toml': 'name = "my-worker"\nmain = "src/index.ts"\ncompatibility_date = "2024-12-01"',
+      'src/index.ts':
+        '// Copyright (c) 2025-2026 BlackRoad OS, Inc.\nexport default { fetch: () => new Response("Hello") }',
+      'wrangler.toml':
+        'name = "my-worker"\nmain = "src/index.ts"\ncompatibility_date = "2024-12-01"',
     },
   },
   {
     name: 'api',
     description: 'Hono API service',
     files: {
-      'src/index.ts': '// Copyright (c) 2025-2026 BlackRoad OS, Inc.\nimport { Hono } from "hono"\nconst app = new Hono()\nexport default app',
-      'package.json': '{ "type": "module", "dependencies": { "hono": "^4.0.0" } }',
+      'src/index.ts':
+        '// Copyright (c) 2025-2026 BlackRoad OS, Inc.\nimport { Hono } from "hono"\nconst app = new Hono()\nexport default app',
+      'package.json':
+        '{ "type": "module", "dependencies": { "hono": "^4.0.0" } }',
     },
   },
 ]

--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -21,10 +21,12 @@ export const agentsCommand = new Command('agents')
         console.log(JSON.stringify(data.agents, null, 2))
         return
       }
-      console.log(formatTable(
-        ['Name', 'Title', 'Role'],
-        data.agents.map((a) => [a.name, a.title, a.role]),
-      ))
+      console.log(
+        formatTable(
+          ['Name', 'Title', 'Role'],
+          data.agents.map((a) => [a.name, a.title, a.role]),
+        ),
+      )
     } catch {
       logger.error('Failed to fetch agents from gateway.')
     }

--- a/src/cli/commands/gateway.ts
+++ b/src/cli/commands/gateway.ts
@@ -3,8 +3,9 @@ import { Command } from 'commander'
 import { GatewayClient } from '../../core/client.js'
 import { logger } from '../../core/logger.js'
 
-export const gatewayCommand = new Command('gateway')
-  .description('Gateway management')
+export const gatewayCommand = new Command('gateway').description(
+  'Gateway management',
+)
 
 gatewayCommand
   .command('health')
@@ -12,7 +13,9 @@ gatewayCommand
   .action(async () => {
     const client = new GatewayClient()
     try {
-      const health = await client.get<{ status: string; version: string }>('/v1/health')
+      const health = await client.get<{ status: string; version: string }>(
+        '/v1/health',
+      )
       logger.success(`Gateway is ${health.status} (v${health.version})`)
     } catch {
       logger.error('Gateway is unreachable.')

--- a/src/cli/commands/invoke.ts
+++ b/src/cli/commands/invoke.ts
@@ -10,7 +10,10 @@ export const invokeCommand = new Command('invoke')
   .action(async (agent: string, task: string) => {
     const client = new GatewayClient()
     try {
-      const result = await client.post<{ content: string }>('/v1/invoke', { agent, task })
+      const result = await client.post<{ content: string }>('/v1/invoke', {
+        agent,
+        task,
+      })
       console.log(result.content)
     } catch {
       logger.error(`Failed to invoke agent "${agent}".`)

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -7,5 +7,7 @@ export const logsCommand = new Command('logs')
   .option('-n <lines>', 'Number of lines', '50')
   .action((opts: { n: string }) => {
     logger.info(`Tailing last ${opts.n} log lines...`)
-    logger.warn('Log tailing not yet implemented. Use wrangler tail or railway logs.')
+    logger.warn(
+      'Log tailing not yet implemented. Use wrangler tail or railway logs.',
+    )
   })

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -8,8 +8,14 @@ export const statusCommand = new Command('status')
   .action(async () => {
     const client = new GatewayClient()
     try {
-      const health = await client.get<{ status: string; version: string; uptime: number }>('/v1/health')
-      logger.success(`Gateway: ${health.status} (v${health.version}, uptime: ${Math.round(health.uptime)}s)`)
+      const health = await client.get<{
+        status: string
+        version: string
+        uptime: number
+      }>('/v1/health')
+      logger.success(
+        `Gateway: ${health.status} (v${health.version}, uptime: ${Math.round(health.uptime)}s)`,
+      )
       const agents = await client.get<{ agents: unknown[] }>('/v1/agents')
       logger.info(`Agents: ${agents.agents.length} registered`)
     } catch {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -4,7 +4,8 @@ export class GatewayClient {
   readonly baseUrl: string
 
   constructor(baseUrl?: string) {
-    this.baseUrl = baseUrl ?? process.env['BLACKROAD_GATEWAY_URL'] ?? 'http://127.0.0.1:8787'
+    this.baseUrl =
+      baseUrl ?? process.env['BLACKROAD_GATEWAY_URL'] ?? 'http://127.0.0.1:8787'
   }
 
   async get<T>(path: string): Promise<T> {

--- a/src/formatters/brand.ts
+++ b/src/formatters/brand.ts
@@ -8,10 +8,23 @@ export const brand = {
   electricBlue: chalk.hex('#2979FF'),
 
   logo() {
-    return this.hotPink('▙') + this.amber('▟') + ' ' + this.violet('BlackRoad') + ' ' + this.electricBlue('OS')
+    return (
+      this.hotPink('▙') +
+      this.amber('▟') +
+      ' ' +
+      this.violet('BlackRoad') +
+      ' ' +
+      this.electricBlue('OS')
+    )
   },
 
   header(text: string) {
-    return this.hotPink('━'.repeat(60)) + '\n' + chalk.bold(text) + '\n' + this.hotPink('━'.repeat(60))
+    return (
+      this.hotPink('━'.repeat(60)) +
+      '\n' +
+      chalk.bold(text) +
+      '\n' +
+      this.hotPink('━'.repeat(60))
+    )
   },
 }

--- a/src/formatters/table.ts
+++ b/src/formatters/table.ts
@@ -9,9 +9,5 @@ export function formatTable(headers: string[], rows: string[][]): string {
   const formatRow = (row: string[]) =>
     row.map((cell, i) => ` ${(cell ?? '').padEnd(widths[i])} `).join('│')
 
-  return [
-    formatRow(headers),
-    sep,
-    ...rows.map(formatRow),
-  ].join('\n')
+  return [formatRow(headers), sep, ...rows.map(formatRow)].join('\n')
 }

--- a/test/core/client.test.ts
+++ b/test/core/client.test.ts
@@ -14,17 +14,27 @@ describe('GatewayClient', () => {
   })
 
   it('should throw on non-ok response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'Error' }))
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500, statusText: 'Error' }),
+    )
     const client = new GatewayClient()
-    await expect(client.get('/v1/health')).rejects.toThrow('GET /v1/health failed: 500 Error')
+    await expect(client.get('/v1/health')).rejects.toThrow(
+      'GET /v1/health failed: 500 Error',
+    )
     vi.unstubAllGlobals()
   })
 
   it('should return parsed JSON on success', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ status: 'healthy' }),
-    }))
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ status: 'healthy' }),
+      }),
+    )
     const client = new GatewayClient()
     const result = await client.get<{ status: string }>('/v1/health')
     expect(result.status).toBe('healthy')

--- a/test/formatters/table.test.ts
+++ b/test/formatters/table.test.ts
@@ -4,7 +4,13 @@ import { formatTable } from '../../src/formatters/table.js'
 
 describe('formatTable', () => {
   it('should format headers and rows', () => {
-    const result = formatTable(['Name', 'Role'], [['alice', 'ops'], ['octavia', 'arch']])
+    const result = formatTable(
+      ['Name', 'Role'],
+      [
+        ['alice', 'ops'],
+        ['octavia', 'arch'],
+      ],
+    )
     expect(result).toContain('Name')
     expect(result).toContain('alice')
     expect(result).toContain('octavia')


### PR DESCRIPTION
- Add blackroad-core/package.json with "type": "commonjs" so gateway
  tests (125 assertions) can use require() without ESM conflicts
- Add .prettierignore to scope formatting checks to src/ and test/ only
- Auto-format src/test files to satisfy prettier --check
- Update CI workflow: Node 22 (matches engines field), remove
  continue-on-error so failures are caught, add typecheck + lint +
  gateway test steps

https://claude.ai/code/session_01KppDmLwux3uSmzt6wqVsLq