### PR TITLE
feat: add BR·ED code editor — multi-tab editor with command palette, find, minimap

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -809,9 +809,18 @@ function renderPalette() {
   filteredCmds.forEach((cmd, i) => {
     const item = document.createElement('div');
     item.className = 'palette-item' + (i===palSel?' selected':'');
-    item.innerHTML = `<span class="palette-item-icon">${cmd.icon}</span>
-      <span class="palette-item-label">${cmd.label}</span>
-      <span class="palette-item-shortcut">${cmd.shortcut}</span>`;
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'palette-item-icon';
+    iconSpan.textContent = cmd.icon;
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'palette-item-label';
+    labelSpan.textContent = cmd.label;
+    const shortcutSpan = document.createElement('span');
+    shortcutSpan.className = 'palette-item-shortcut';
+    shortcutSpan.textContent = cmd.shortcut || '';
+    item.appendChild(iconSpan);
+    item.appendChild(labelSpan);
+    item.appendChild(shortcutSpan);
     item.onclick = () => { cmd.fn(); closePalette(); };
     list.appendChild(item);
   });


### PR DESCRIPTION
Single-file code editor (editor.html) with:
- Multi-tab interface with file switching (agent-core.js, memory.py, README.md)
- Line-numbered gutter with current line highlight
- Find bar with match navigation (Ctrl/Cmd+F)
- Command palette with fuzzy search (Ctrl/Cmd+K)
- Decorative minimap showing code density
- Status bar with cursor position, word/line count, language
- Save flash notification (Ctrl/Cmd+S)
- Tab-to-spaces, keyboard shortcuts, scroll sync
- BlackRoad brand gradient accents, JetBrains Mono font

https://claude.ai/code/session_018xG6vVpYdPyXxyowEVvkk1